### PR TITLE
Fix: SQL queries using NOW() rely on MySQL timezone instead of shop timezone

### DIFF
--- a/statsbestproducts.php
+++ b/statsbestproducts.php
@@ -152,7 +152,7 @@ class statsbestproducts extends ModuleGrid
 				ROUND(AVG(od.unit_price_tax_excl / o.conversion_rate), 2) as avgPriceSold,
 				IFNULL(stock.quantity, 0) as quantity,
 				IFNULL(SUM(od.product_quantity), 0) AS totalQuantitySold,
-				ROUND(IFNULL(IFNULL(SUM(od.product_quantity), 0) / (1 + LEAST(TO_DAYS(' . $array_date_between[1] . '), TO_DAYS(NOW())) - GREATEST(TO_DAYS(' . $array_date_between[0] . '), TO_DAYS(product_shop.date_add))), 0), 2) as averageQuantitySold,
+				ROUND(IFNULL(IFNULL(SUM(od.product_quantity), 0) / (1 + LEAST(TO_DAYS(' . $array_date_between[1] . '), TO_DAYS(\'' . date('Y-m-d') . '\')) - GREATEST(TO_DAYS(' . $array_date_between[0] . '), TO_DAYS(product_shop.date_add))), 0), 2) as averageQuantitySold,
 				ROUND(IFNULL(SUM((od.unit_price_tax_excl * od.product_quantity) / o.conversion_rate), 0), 2) AS totalPriceSold,
 				(
 					SELECT IFNULL(SUM(pv.counter), 0)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | The best-products stats query used \`TO_DAYS(NOW())\` to compute the average daily sales, which relies on the MySQL server timezone (UTC by default). Replaced with \`TO_DAYS('Y-m-d')\` computed in PHP so the shop's configured timezone is used.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | Related to PrestaShop/PrestaShop#30828
| Related PRs       | PrestaShop/PrestaShop#41596
| Sponsor company   | PrestaShop SA

---
**Related CI issue:** #29